### PR TITLE
Improve Welcome page styling

### DIFF
--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -179,18 +179,20 @@ const Welcome = () => {
             />
           </div>
 
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="acceptEmail"
-              checked={acceptEmail}
-              onCheckedChange={(checked) => setAcceptEmail(checked as boolean)}
-            />
-            <Label
-              htmlFor="acceptEmail"
-              className="text-sm text-gray-600"
-            >
-              Send me occasional updates on my group activities
-            </Label>
+          <div className="bg-sky-100 p-4 rounded-lg">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="acceptEmail"
+                checked={acceptEmail}
+                onCheckedChange={(checked) => setAcceptEmail(checked as boolean)}
+              />
+              <Label
+                htmlFor="acceptEmail"
+                className="text-sm text-gray-700"
+              >
+                Yes, please send occasional updates on my groups' activities.
+              </Label>
+            </div>
           </div>
 
           <Button
@@ -207,3 +209,4 @@ const Welcome = () => {
 };
 
 export default Welcome;
+


### PR DESCRIPTION
Improved styling of the email acceptance checkbox and text on the /welcome/ page.  The checkbox and text are now enclosed in a light blue box, and the text has been updated.